### PR TITLE
:shirt: Make hidden lifetime explicit in delimit_by

### DIFF
--- a/src/ext/buf_read.rs
+++ b/src/ext/buf_read.rs
@@ -64,7 +64,7 @@ pub(crate) trait BufReadExt {
     }
 
     #[inline]
-    fn delimit_by(self, delimiter: &[u8]) -> Delimited<Self>
+    fn delimit_by(self, delimiter: &[u8]) -> Delimited<'_, Self>
     where
         Self: Sized,
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the `delimit_by` method's return type to enforce stricter type safety, ensuring the returned iterator properly references the provided delimiter across API boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->