### PR TITLE
:memo: Render README as crate docs and document all CLI options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 mod cli;
 mod ext;
 mod range;


### PR DESCRIPTION
- Add #![doc = include_str!("../README.md")] so docs.rs shows the README as the crate's front page (binary-only crate has no public API)
- Document -c, --delimiter, -q and --io-buffer-size, plus the multi-file header behavior, which were missing from the README
- Fix backtick typo in the 5:+10 example and note that start:+count is experimental

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced usage documentation with clearer descriptions of default line-slicing behavior
  * Added documentation for CLI options including byte slicing, custom delimiters, quiet mode, and I/O buffer sizing
  * Clarified multi-file output header behavior
  * Expanded examples section with byte-slicing and delimiter-based field slicing examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->