### PR TITLE
:sparkles: Add -z/--null delimiter and -e/--escape for --delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ slice 5:+10 file.txt
 
 This command is the same as `slice` 5:15 file.txt`.
 
+```sh
+find . -type f -print0 | slice 0:100 -z
+```
+
+With `-z` (`--null`), records are split on NUL (`\0`) instead of newlines, so it
+interoperates with `find -print0`, `xargs -0`, and `grep -z`.
+
+```sh
+slice 0:3 --delimiter '\t' -e data.tsv
+```
+
+By default `--delimiter` is taken literally. Add `-e` (`--escape`) to interpret
+backslash escapes in the delimiter: `\t`, `\n`, `\r`, `\0`, `\\`, and `\xHH`
+(an arbitrary byte, e.g. `\xff`). This command slices the first three
+tab-separated fields.
+
 For more details, run:
 
 ```sh

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ impl FromStr for NonZeroByteSize {
     about,
     author,
     arg_required_else_help = true,
-    group(ArgGroup::new("mode").args(["lines", "characters"])),
+    group(ArgGroup::new("mode").args(["lines", "characters", "delimiter", "null"])),
 )]
 pub(crate) struct Args {
     #[arg(
@@ -44,6 +44,15 @@ e.g., '50:+50'"
     pub(crate) characters: bool,
     #[arg(long, help = "Slice by delimiter")]
     pub(crate) delimiter: Option<String>,
+    #[arg(short = 'z', long = "null", help = "Use NUL (\\0) as the delimiter")]
+    pub(crate) null: bool,
+    #[arg(
+        short = 'e',
+        long = "escape",
+        requires = "delimiter",
+        help = "Interpret backslash escapes in --delimiter (\\t \\n \\r \\0 \\\\ \\xHH)"
+    )]
+    pub(crate) escape: bool,
     #[arg(
         short,
         help = "Suppresses printing of headers when multiple files are being examined"
@@ -63,6 +72,77 @@ impl Args {
     pub(crate) fn io_buffer_size(&self) -> Option<usize> {
         self.io_buffer_size.map(|it| it.0.as_u64() as usize)
     }
+
+    /// Resolve the effective delimiter bytes. `--null` wins and yields a single
+    /// NUL byte; otherwise `--delimiter` is taken literally unless `--escape`
+    /// is set, in which case backslash escapes are expanded.
+    pub(crate) fn delimiter(&self) -> Result<Option<Vec<u8>>, String> {
+        if self.null {
+            return Ok(Some(vec![0]));
+        }
+        match &self.delimiter {
+            Some(s) if self.escape => unescape(s).map(Some),
+            Some(s) => Ok(Some(s.clone().into_bytes())),
+            None => Ok(None),
+        }
+    }
+}
+
+#[inline]
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Expand C-style backslash escapes (`\t \n \r \0 \\ \xHH`) into raw bytes.
+/// Non-escaped bytes pass through unchanged, so UTF-8 delimiters are preserved.
+fn unescape(s: &str) -> Result<Vec<u8>, String> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b != b'\\' {
+            out.push(b);
+            i += 1;
+            continue;
+        }
+        i += 1;
+        let Some(&esc) = bytes.get(i) else {
+            return Err("trailing backslash in delimiter".to_owned());
+        };
+        match esc {
+            b'n' => out.push(b'\n'),
+            b'r' => out.push(b'\r'),
+            b't' => out.push(b'\t'),
+            b'0' => out.push(0),
+            b'\\' => out.push(b'\\'),
+            b'x' => {
+                let (hi, lo) = match (bytes.get(i + 1), bytes.get(i + 2)) {
+                    (Some(&hi), Some(&lo)) => (hi, lo),
+                    _ => return Err("`\\x` needs two hex digits".to_owned()),
+                };
+                let byte = hex_val(hi).zip(hex_val(lo)).map(|(h, l)| h << 4 | l);
+                match byte {
+                    Some(byte) => out.push(byte),
+                    None => {
+                        return Err(format!(
+                            "invalid hex escape `\\x{}{}`",
+                            hi as char, lo as char
+                        ))
+                    }
+                }
+                i += 2;
+            }
+            other => return Err(format!("unknown escape sequence `\\{}`", other as char)),
+        }
+        i += 1;
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -110,5 +190,67 @@ mod tests {
             .expect("characters arg");
         let help = arg.get_help().expect("help text").to_string();
         assert!(help.to_lowercase().contains("byte"));
+    }
+
+    #[test]
+    fn unescape_basic() {
+        assert_eq!(unescape("\\t").unwrap(), b"\t");
+        assert_eq!(unescape("\\n").unwrap(), b"\n");
+        assert_eq!(unescape("\\r\\n").unwrap(), b"\r\n");
+        assert_eq!(unescape("\\0").unwrap(), [0]);
+        assert_eq!(unescape("\\\\").unwrap(), b"\\");
+        assert_eq!(unescape(",").unwrap(), b",");
+        assert_eq!(unescape("a\\tb").unwrap(), b"a\tb");
+    }
+
+    #[test]
+    fn unescape_hex() {
+        assert_eq!(unescape("\\x41").unwrap(), [0x41]);
+        assert_eq!(unescape("\\xff").unwrap(), [0xff]);
+        assert_eq!(unescape("\\x00\\x01").unwrap(), [0x00, 0x01]);
+    }
+
+    #[test]
+    fn unescape_errors() {
+        assert!(unescape("\\q").is_err());
+        assert!(unescape("trailing\\").is_err());
+        assert!(unescape("\\x").is_err());
+        assert!(unescape("\\xZZ").is_err());
+    }
+
+    #[test]
+    fn delimiter_null() {
+        let args = Args::parse_from(["slice", "-z", "0:"]);
+        assert_eq!(args.delimiter().unwrap(), Some(vec![0]));
+    }
+
+    #[test]
+    fn delimiter_literal_by_default() {
+        let args = Args::parse_from(["slice", "--delimiter", "\\t", "0:"]);
+        assert_eq!(args.delimiter().unwrap(), Some(b"\\t".to_vec()));
+    }
+
+    #[test]
+    fn delimiter_escaped_with_flag() {
+        let args = Args::parse_from(["slice", "--delimiter", "\\t", "-e", "0:"]);
+        assert_eq!(args.delimiter().unwrap(), Some(b"\t".to_vec()));
+    }
+
+    #[test]
+    fn delimiter_none() {
+        let args = Args::parse_from(["slice", "0:"]);
+        assert_eq!(args.delimiter().unwrap(), None);
+    }
+
+    #[test]
+    fn mode_flags_are_mutually_exclusive() {
+        assert!(Args::try_parse_from(["slice", "-z", "-c", "0:"]).is_err());
+        assert!(Args::try_parse_from(["slice", "-z", "--delimiter", ",", "0:"]).is_err());
+        assert!(Args::try_parse_from(["slice", "-c", "--delimiter", ",", "0:"]).is_err());
+    }
+
+    #[test]
+    fn escape_requires_delimiter() {
+        assert!(Args::try_parse_from(["slice", "-e", "0:"]).is_err());
     }
 }

--- a/src/ext/buf_read.rs
+++ b/src/ext/buf_read.rs
@@ -142,4 +142,11 @@ mod tests {
         assert_eq!(b"a||", delimited.next().unwrap().unwrap().as_slice());
         assert_eq!(b"|b|", delimited.next().unwrap().unwrap().as_slice());
     }
+
+    #[test]
+    fn delimit_by_nul() {
+        let mut delimited = BufReader::new(&b"a\0b\0"[..]).delimit_by(&[0]);
+        assert_eq!(b"a\0", delimited.next().unwrap().unwrap().as_slice());
+        assert_eq!(b"b\0", delimited.next().unwrap().unwrap().as_slice());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use crate::{
     ext::{BufReadExt, IteratorExt},
     range::SliceRange,
 };
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use std::{
     fs,
     io::{self, stdin, stdout, BufRead, Read, Write},
@@ -119,13 +119,19 @@ fn multi<
 
 fn entry(args: cli::Args) -> bool {
     let io_buffer_size = args.io_buffer_size();
+    let delimiter = match args.delimiter() {
+        Ok(delimiter) => delimiter,
+        Err(e) => cli::Args::command()
+            .error(clap::error::ErrorKind::ValueValidation, e)
+            .exit(),
+    };
     if args.files.is_empty() {
         let input = buf_reader(stdin().lock(), io_buffer_size);
         let output = buf_writer(stdout().lock(), io_buffer_size);
         let result = if args.characters {
             character_mode(input, output, &args.range)
-        } else if let Some(delimiter) = args.delimiter {
-            delimit_mode(input, output, delimiter.as_bytes(), &args.range)
+        } else if let Some(delimiter) = delimiter.as_deref() {
+            delimit_mode(input, output, delimiter, &args.range)
         } else {
             line_mode(input, output, &args.range)
         };
@@ -147,14 +153,14 @@ fn entry(args: cli::Args) -> bool {
                 print_header,
                 |input, output, range| character_mode(input, output, range),
             )
-        } else if let Some(delimiter) = args.delimiter {
+        } else if let Some(delimiter) = delimiter.as_deref() {
             multi(
                 &args.files,
                 output,
                 |input| buf_reader(input, io_buffer_size),
                 &args.range,
                 print_header,
-                |input, output, range| delimit_mode(input, output, delimiter.as_bytes(), range),
+                |input, output, range| delimit_mode(input, output, delimiter, range),
             )
         } else {
             multi(

--- a/tests/cmd/basic_no_args_help.stderr
+++ b/tests/cmd/basic_no_args_help.stderr
@@ -17,6 +17,10 @@ Options:
           Slice the bytes
       --delimiter <DELIMITER>
           Slice by delimiter
+  -z, --null
+          Use NUL (/0) as the delimiter
+  -e, --escape
+          Interpret backslash escapes in --delimiter (/t /n /r /0 // /xHH)
   -q
           Suppresses printing of headers when multiple files are being examined
       --io-buffer-size <IO_BUFFER_SIZE>

--- a/tests/cmd/option_help_long_stdout.stdout
+++ b/tests/cmd/option_help_long_stdout.stdout
@@ -17,6 +17,10 @@ Options:
           Slice the bytes
       --delimiter <DELIMITER>
           Slice by delimiter
+  -z, --null
+          Use NUL (/0) as the delimiter
+  -e, --escape
+          Interpret backslash escapes in --delimiter (/t /n /r /0 // /xHH)
   -q
           Suppresses printing of headers when multiple files are being examined
       --io-buffer-size <IO_BUFFER_SIZE>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added `-z/--null` flag to use NUL bytes as delimiter, enabling seamless integration with `find -print0`, `xargs -0`, and `grep -z`
  - Added `-e/--escape` flag to interpret backslash escape sequences (`\t`, `\n`, `\r`, `\0`, `\\`, `\xHH`) in custom delimiters

* **Documentation**
  - Extended README with examples demonstrating delimiter piping and tab-separated field parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->