### PR TITLE
Refactor/slice range parse error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ version = "0.4.3"
 dependencies = [
  "bytesize",
  "clap",
+ "thiserror",
  "trycmd",
 ]
 
@@ -492,6 +493,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 [dependencies]
 bytesize = "2.3.1"
 clap = { version = "4.6.1", features = ["derive"] }
-thiserror = "2"
+thiserror = "2.0.18"
 
 [[bin]]
 name = "slice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.85"
 [dependencies]
 bytesize = "2.3.1"
 clap = { version = "4.6.1", features = ["derive"] }
+thiserror = "2"
 
 [[bin]]
 name = "slice"

--- a/src/range.rs
+++ b/src/range.rs
@@ -11,6 +11,39 @@ pub(crate) struct SliceRange {
     pub(crate) step: Option<NonZeroUsize>,
 }
 
+/// Which numeric field of a `start:end:step` range failed to parse.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub(crate) enum RangeField {
+    Start,
+    End,
+    Step,
+}
+
+impl std::fmt::Display for RangeField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            RangeField::Start => "start",
+            RangeField::End => "end",
+            RangeField::Step => "step",
+        })
+    }
+}
+
+/// Error produced while parsing a `SliceRange` from its `start:end:step` form.
+#[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
+pub(crate) enum ParseSliceRangeError {
+    #[error("range requires a ':' separator (e.g. '3:4', '3:', or ':3')")]
+    MissingColon,
+    #[error("invalid {field} value '{value}': {source}")]
+    InvalidField {
+        field: RangeField,
+        value: String,
+        source: ParseIntError,
+    },
+    #[error("too many ':' separators in range (expected at most start:end:step)")]
+    TooManyParts,
+}
+
 impl SliceRange {
     /// Render a human-readable description of what this resolved range selects,
     /// without reading any input. `unit` names the elements (e.g. "line").
@@ -108,35 +141,43 @@ fn ordinal_suffix(n: usize) -> &'static str {
 }
 
 impl FromStr for SliceRange {
-    type Err = String;
+    type Err = ParseSliceRangeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        fn parse_or<T: FromStr<Err = ParseIntError>>(s: &str, empty: T) -> Result<T, String> {
-            let result: Result<T, ParseIntError> = s.parse();
-            match result {
+        fn parse_or<T: FromStr<Err = ParseIntError>>(
+            s: &str,
+            empty: T,
+            field: RangeField,
+        ) -> Result<T, ParseSliceRangeError> {
+            match s.parse::<T>() {
                 Ok(v) => Ok(v),
                 Err(err) if *err.kind() == IntErrorKind::Empty => Ok(empty),
-                Err(err) => Err(err),
+                Err(source) => Err(ParseSliceRangeError::InvalidField {
+                    field,
+                    value: s.to_owned(),
+                    source,
+                }),
             }
-            .map_err(|e| e.to_string())
         }
-        fn parse_opt(s: &str) -> Result<Option<usize>, String> {
+        fn parse_opt(s: &str, field: RangeField) -> Result<Option<usize>, ParseSliceRangeError> {
             match s.parse::<usize>() {
                 Ok(v) => Ok(Some(v)),
                 Err(err) if *err.kind() == IntErrorKind::Empty => Ok(None),
-                Err(err) => Err(err.to_string()),
+                Err(source) => Err(ParseSliceRangeError::InvalidField {
+                    field,
+                    value: s.to_owned(),
+                    source,
+                }),
             }
         }
         let mut ptn = s.split(':');
-        let maybe_start = ptn
-            .next()
-            .ok_or_else(|| "range start must be needed".to_owned())?;
-        let start: usize = parse_or(maybe_start, 0)?;
-        let maybe_end = ptn.next().ok_or_else(|| {
-            "range requires a ':' separator (e.g. '3:4', '3:', or ':3')".to_owned()
-        })?;
+        // `split` always yields at least one element, so the `start` token is
+        // present even for an empty input (which parses to the default 0).
+        let maybe_start = ptn.next().unwrap_or("");
+        let start: usize = parse_or(maybe_start, 0, RangeField::Start)?;
+        let maybe_end = ptn.next().ok_or(ParseSliceRangeError::MissingColon)?;
         let (start, end) = if let Some(maybe_lines) = maybe_end.strip_prefix("+-") {
-            match parse_opt(maybe_lines)? {
+            match parse_opt(maybe_lines, RangeField::End)? {
                 Some(lines) => (
                     start.saturating_sub(lines),
                     Some(start.saturating_add(lines)),
@@ -144,21 +185,19 @@ impl FromStr for SliceRange {
                 None => (0, None),
             }
         } else if let Some(maybe_lines) = maybe_end.strip_prefix('+') {
-            match parse_opt(maybe_lines)? {
+            match parse_opt(maybe_lines, RangeField::End)? {
                 Some(lines) => (start, Some(start.saturating_add(lines))),
                 None => (start, None),
             }
         } else {
-            (start, parse_opt(maybe_end)?)
+            (start, parse_opt(maybe_end, RangeField::End)?)
         };
         let step = match ptn.next() {
-            Some(step) => Some(parse_or(step, NonZeroUsize::MIN)?),
+            Some(step) => Some(parse_or(step, NonZeroUsize::MIN, RangeField::Step)?),
             None => None,
         };
         if ptn.next().is_some() {
-            return Err(
-                "too many ':' separators in range (expected at most start:end:step)".to_owned(),
-            );
+            return Err(ParseSliceRangeError::TooManyParts);
         }
         Ok(Self { start, end, step })
     }
@@ -426,8 +465,9 @@ mod tests {
         #[test]
         fn missing_colon() {
             let err = SliceRange::from_str("3").expect_err("bare number must be rejected");
+            assert_eq!(err, ParseSliceRangeError::MissingColon);
             assert_eq!(
-                err,
+                err.to_string(),
                 "range requires a ':' separator (e.g. '3:4', '3:', or ':3')"
             );
         }
@@ -437,6 +477,35 @@ mod tests {
             assert!(SliceRange::from_str("1:2:3:4").is_err());
             assert!(SliceRange::from_str("1:2:3:4:5").is_err());
             assert!(SliceRange::from_str(":::").is_err());
+        }
+
+        #[test]
+        fn invalid_field_names_which_part() {
+            assert!(matches!(
+                SliceRange::from_str("a:1").unwrap_err(),
+                ParseSliceRangeError::InvalidField {
+                    field: RangeField::Start,
+                    ..
+                }
+            ));
+            assert!(matches!(
+                SliceRange::from_str("1:a").unwrap_err(),
+                ParseSliceRangeError::InvalidField {
+                    field: RangeField::End,
+                    ..
+                }
+            ));
+            assert!(matches!(
+                SliceRange::from_str("1:1:b").unwrap_err(),
+                ParseSliceRangeError::InvalidField {
+                    field: RangeField::Step,
+                    ..
+                }
+            ));
+            assert!(SliceRange::from_str("1:5:x")
+                .unwrap_err()
+                .to_string()
+                .starts_with("invalid step value 'x':"));
         }
     }
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -40,6 +40,8 @@ pub(crate) enum ParseSliceRangeError {
         value: String,
         source: ParseIntError,
     },
+    #[error("a relative end ('+' or '+-') requires a count (e.g. '5:+3' or '5:+-3')")]
+    MissingRelativeAmount,
     #[error("too many ':' separators in range (expected at most start:end:step)")]
     TooManyParts,
 }
@@ -144,23 +146,11 @@ impl FromStr for SliceRange {
     type Err = ParseSliceRangeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        fn parse_or<T: FromStr<Err = ParseIntError>>(
+        fn parse<T: FromStr<Err = ParseIntError>>(
             s: &str,
-            empty: T,
             field: RangeField,
-        ) -> Result<T, ParseSliceRangeError> {
+        ) -> Result<Option<T>, ParseSliceRangeError> {
             match s.parse::<T>() {
-                Ok(v) => Ok(v),
-                Err(err) if *err.kind() == IntErrorKind::Empty => Ok(empty),
-                Err(source) => Err(ParseSliceRangeError::InvalidField {
-                    field,
-                    value: s.to_owned(),
-                    source,
-                }),
-            }
-        }
-        fn parse_opt(s: &str, field: RangeField) -> Result<Option<usize>, ParseSliceRangeError> {
-            match s.parse::<usize>() {
                 Ok(v) => Ok(Some(v)),
                 Err(err) if *err.kind() == IntErrorKind::Empty => Ok(None),
                 Err(source) => Err(ParseSliceRangeError::InvalidField {
@@ -170,30 +160,27 @@ impl FromStr for SliceRange {
                 }),
             }
         }
+        let relative_amount = |amount: &str| -> Result<usize, ParseSliceRangeError> {
+            parse(amount, RangeField::End)?.ok_or(ParseSliceRangeError::MissingRelativeAmount)
+        };
+
         let mut ptn = s.split(':');
-        // `split` always yields at least one element, so the `start` token is
-        // present even for an empty input (which parses to the default 0).
-        let maybe_start = ptn.next().unwrap_or("");
-        let start: usize = parse_or(maybe_start, 0, RangeField::Start)?;
+        let start = parse(ptn.next().unwrap_or(""), RangeField::Start)?.unwrap_or(0usize);
         let maybe_end = ptn.next().ok_or(ParseSliceRangeError::MissingColon)?;
-        let (start, end) = if let Some(maybe_lines) = maybe_end.strip_prefix("+-") {
-            match parse_opt(maybe_lines, RangeField::End)? {
-                Some(lines) => (
-                    start.saturating_sub(lines),
-                    Some(start.saturating_add(lines)),
-                ),
-                None => (0, None),
-            }
-        } else if let Some(maybe_lines) = maybe_end.strip_prefix('+') {
-            match parse_opt(maybe_lines, RangeField::End)? {
-                Some(lines) => (start, Some(start.saturating_add(lines))),
-                None => (start, None),
-            }
+        let (start, end) = if let Some(amount) = maybe_end.strip_prefix("+-") {
+            let lines = relative_amount(amount)?;
+            (
+                start.saturating_sub(lines),
+                Some(start.saturating_add(lines)),
+            )
+        } else if let Some(amount) = maybe_end.strip_prefix('+') {
+            let lines = relative_amount(amount)?;
+            (start, Some(start.saturating_add(lines)))
         } else {
-            (start, parse_opt(maybe_end, RangeField::End)?)
+            (start, parse(maybe_end, RangeField::End)?)
         };
         let step = match ptn.next() {
-            Some(step) => Some(parse_or(step, NonZeroUsize::MIN, RangeField::Step)?),
+            Some(step) => Some(parse(step, RangeField::Step)?.unwrap_or(NonZeroUsize::MIN)),
             None => None,
         };
         if ptn.next().is_some() {
@@ -348,32 +335,6 @@ mod tests {
         )
     }
 
-    #[test]
-    fn plus_sign_saturates_end() {
-        let slice = SliceRange::from_str("5:+").expect("parse failed.");
-        assert_eq!(
-            slice,
-            SliceRange {
-                start: 5,
-                end: None,
-                step: None,
-            }
-        )
-    }
-
-    #[test]
-    fn plus_minus_sign_saturates_both_ends() {
-        let slice = SliceRange::from_str("5:+-").expect("parse failed.");
-        assert_eq!(
-            slice,
-            SliceRange {
-                start: 0,
-                end: None,
-                step: None,
-            }
-        )
-    }
-
     mod explain {
         use super::*;
 
@@ -506,6 +467,29 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .starts_with("invalid step value 'x':"));
+        }
+
+        #[test]
+        fn relative_end_requires_a_count() {
+            assert_eq!(
+                SliceRange::from_str("5:+").unwrap_err(),
+                ParseSliceRangeError::MissingRelativeAmount
+            );
+            assert_eq!(
+                SliceRange::from_str("5:+-").unwrap_err(),
+                ParseSliceRangeError::MissingRelativeAmount
+            );
+        }
+
+        #[test]
+        fn relative_end_rejects_non_numeric_count() {
+            assert!(matches!(
+                SliceRange::from_str("1:+x").unwrap_err(),
+                ParseSliceRangeError::InvalidField {
+                    field: RangeField::End,
+                    ..
+                }
+            ));
         }
     }
 }

--- a/tests/cmd/basic_invalid_range_value.stderr
+++ b/tests/cmd/basic_invalid_range_value.stderr
@@ -1,3 +1,3 @@
-error: invalid value 'a:1' for '<RANGE>': invalid digit found in string
+error: invalid value 'a:1' for '<RANGE>': invalid start value 'a': invalid digit found in string
 
 For more information, try '--help'.

--- a/tests/cmd/basic_non_numeric_start_errors.stderr
+++ b/tests/cmd/basic_non_numeric_start_errors.stderr
@@ -1,3 +1,3 @@
-error: invalid value 'abc' for '<RANGE>': invalid digit found in string
+error: invalid value 'abc' for '<RANGE>': invalid start value 'abc': invalid digit found in string
 
 For more information, try '--help'.

--- a/tests/cmd/basic_non_numeric_step_errors.stderr
+++ b/tests/cmd/basic_non_numeric_step_errors.stderr
@@ -1,3 +1,3 @@
-error: invalid value '1:5:x' for '<RANGE>': invalid digit found in string
+error: invalid value '1:5:x' for '<RANGE>': invalid step value 'x': invalid digit found in string
 
 For more information, try '--help'.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for invalid range values to provide more specific diagnostic information, indicating exactly which field (start, end, or step) failed to parse and the underlying cause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->