### PR TITLE
:sparkles: Add the cheatsheet logo, favicon, and Open Graph image

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,10 +29,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust
-      # docs/index.html is gitignored, so it must be regenerated from the SSOT
-      # (docs/cheatsheet.toml) before the artifact is uploaded.
-      - name: Generate docs/index.html
-        run: cargo xtask gen
+      - name: Install docs image renderer
+        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends librsvg2-bin
+      # docs/index.html and the raster images (og.png, apple-touch-icon.png)
+      # are gitignored, so they must be regenerated from the SSOT/SVG sources
+      # before the artifact is uploaded.
+      - name: Generate docs
+        run: |
+          cargo xtask gen
+          rsvg-convert -w 1200 -h 630 -f png -o docs/og.png docs/og.svg
+          rsvg-convert -w 180 -h 180 -f png -o docs/apple-touch-icon.png docs/favicon.svg
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -584,3 +584,5 @@ FodyWeavers.xsd
 /docs/index.html
 /docs/sitemap.xml
 /docs/llms.txt
+/docs/og.png
+/docs/apple-touch-icon.png

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="docs/logo.svg" alt="slice" width="210">
+</p>
+
 # Slice
 
 Slice is a command-line tool written in Rust that allows you to slice the contents of a file using syntax similar to Python's slice notation.

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="slice logo: a colon between square brackets">
+  <title>slice</title>
+  <rect width="64" height="64" rx="14" fill="#14171a"/>
+  <g fill="none" stroke="#6ea8ff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M26 15 H15 V49 H26"/>
+    <path d="M38 15 H49 V49 H38"/>
+  </g>
+  <circle cx="32" cy="26" r="4.5" fill="#e6e8ea"/>
+  <circle cx="32" cy="38" r="4.5" fill="#e6e8ea"/>
+</svg>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 72" role="img" aria-label="slice — a colon between square brackets, with the wordmark slice">
+  <title>slice</title>
+  <rect width="210" height="72" rx="16" fill="#14171a"/>
+  <!-- The [ : ] mark (same geometry as favicon.svg, sans its own tile). -->
+  <g transform="translate(14,8) scale(0.875)">
+    <g fill="none" stroke="#6ea8ff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M26 15 H15 V49 H26"/>
+      <path d="M38 15 H49 V49 H38"/>
+    </g>
+    <circle cx="32" cy="26" r="4.5" fill="#e6e8ea"/>
+    <circle cx="32" cy="38" r="4.5" fill="#e6e8ea"/>
+  </g>
+  <text x="84" y="48" font-family="ui-monospace, &quot;SF Mono&quot;, Menlo, Consolas, monospace" font-size="34" font-weight="700" fill="#e6e8ea">slice</text>
+</svg>

--- a/xtask/templates/cheatsheet.html
+++ b/xtask/templates/cheatsheet.html
@@ -7,15 +7,22 @@
 <meta name="description" content="Map head, tail, sed, awk, and dd line and byte ranges to one Python-style slice syntax (start:end:step): line ranges, last N lines, every Nth line.">
 <link rel="canonical" href="https://chantsune.github.io/slice/">
 <meta name="robots" content="index, follow">
+<link rel="icon" href="favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="apple-touch-icon.png">
 <meta property="og:type" content="article">
 <meta property="og:title" content="slice cheatsheet — extract line &amp; byte ranges (head, tail, sed, awk, dd in one syntax)">
 <meta property="og:description" content="One Python-style slice syntax for the line and byte ranges you reach for head, tail, sed, awk, and dd to do.">
 <meta property="og:url" content="https://chantsune.github.io/slice/">
 <meta property="og:site_name" content="slice">
-<!-- TODO: add og:image / twitter:image once docs/og.png (1200x630) exists, plus twitter:card=summary_large_image -->
-<meta name="twitter:card" content="summary">
+<meta property="og:image" content="https://chantsune.github.io/slice/og.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="slice cheatsheet preview showing head, tail, sed, awk, and dd commands mapped to slice syntax">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="slice cheatsheet — extract line &amp; byte ranges">
 <meta name="twitter:description" content="One Python-style slice syntax for head, tail, sed, awk, and dd line and byte ranges.">
+<meta name="twitter:image" content="https://chantsune.github.io/slice/og.png">
+<meta name="twitter:image:alt" content="slice cheatsheet preview showing head, tail, sed, awk, and dd commands mapped to slice syntax">
 <link rel="stylesheet" href="style.css">
 <script type="application/ld+json">
 {


### PR DESCRIPTION
A bracket-and-colon [ : ] mark echoing the slice syntax: docs/logo.svg (the README header lockup with wordmark) and docs/favicon.svg (the page icon), plus the Open Graph / Twitter card image for link previews.

The raster outputs — og.png and apple-touch-icon.png — are rasterized from the committed SVG sources by rsvg-convert during the Pages build and gitignored, so they cannot drift from the vectors (the same source-of- truth approach as the generated HTML).