### PR TITLE
:memo: Reorganize the README around orientation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for taking an interest in slice! Contributions of every kind are
+welcome — bug reports, fixes, new features, documentation, tests, or a question
+that nudges the docs to be clearer. No contribution is too small.
+
+Reaching for AI tools to draft or review your changes is fine; there's no
+judgment here. What matters is that whoever opens the pull request owns it:
+understand what you're submitting, respond to review, and see it through to the
+end. Please don't open a PR you aren't prepared to carry across the finish line.
+
+## Development environment
+
+Open the repository in a [Dev Container](https://containers.dev/) (VS Code
+"Reopen in Container" or GitHub Codespaces) to get a ready-to-use environment.
+The container installs the toolchain declared in `flake.nix` via Nix and
+activates it automatically with [direnv](https://direnv.net/), so `cargo test`
+works out of the box.
+
+## Tests
+
+Run the unit tests and the end-to-end CLI tests together:
+
+```sh
+cargo test
+```
+
+CLI behavior is locked under `tests/cmd/` via [`trycmd`]: each `*.toml` case runs the built
+`slice` binary and compares its stdout, stderr, and exit code against sibling golden files.
+
+After an intentional behavior change, regenerate the expected outputs and review the diff:
+
+```sh
+TRYCMD=overwrite cargo test --test cli   # update existing golden files in place
+```
+
+When adding a brand-new case, write its `*.toml` (plus `*.stdin` and/or `*.in/`), capture the
+actual output with `TRYCMD=dump cargo test --test cli`, and copy `dump/<name>.stdout` /
+`dump/<name>.stderr` into `tests/cmd/`. Keep OS-specific lines redacted with `[..]` (currently the
+I/O-error message and the `--version` string).
+
+[`trycmd`]: https://docs.rs/trycmd

--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ The script downloads the matching prebuilt binary from the latest GitHub release
 and installs it. Set `SLICE_VERSION` to pin a version or `SLICE_INSTALL_DIR` to
 choose the install location.
 
+### Prebuilt binaries
+
+Prebuilt archives for Linux, macOS, and Windows (x86 and ARM) are published on
+the [GitHub Releases](https://github.com/ChanTsune/slice/releases) page; see that
+page for the targets covered by the latest release. Each archive bundles shell
+completions (`complete/`) and the man page (`doc/`) alongside the binary.
+
+[`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) fetches and
+installs the matching archive automatically:
+
+```sh
+cargo binstall slice-command
+```
+
 ### Via Homebrew
 
 ```sh
@@ -48,20 +62,6 @@ nix-env --install -f https://github.com/chantsune/slice/tarball/main
 
 ```sh
 cargo install slice-command
-```
-
-### Prebuilt binaries
-
-Prebuilt archives for Linux, macOS, and Windows (x86 and ARM) are published on
-the [GitHub Releases](https://github.com/ChanTsune/slice/releases) page; see that
-page for the targets covered by the latest release. Each archive bundles shell
-completions (`complete/`) and the man page (`doc/`) alongside the binary.
-
-[`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) fetches and
-installs the matching archive automatically:
-
-```sh
-cargo binstall slice-command
 ```
 
 ### From Source (via Cargo)
@@ -139,32 +139,6 @@ version (byte ranges, every-Nth-line, NUL records, caveats, and a
 | Line 7 only | `sed -n '7p'  /  awk 'NR==7'` | `slice 6:7` |
 | From line 10 to the end | `sed -n '10,$p'` | `slice 9:` |
 
-#### Byte ranges from a file (head -c, tail -c, dd without dd)
-
-| Task | coreutils / sed / awk / dd | slice |
-| --- | --- | --- |
-| First 5 bytes | `head -c 5` | `slice -b :5` |
-| Last 5 bytes | `tail -c 5` | `slice -b -5:` |
-| All but the last 5 bytes | `head -c -5` | `slice -b :-5` |
-| From byte 6 to the end | `tail -c +6` | `slice -b 5:` |
-| Bytes 5 through 14 | `dd bs=1 skip=5 count=10` | `slice -b 5:15` |
-| First 4 bytes | `dd bs=1 count=4` | `slice -b 0:4` |
-| From byte 10 to the end | `dd bs=1 skip=10` | `slice -b 10:` |
-| A block range (bs=4 skip=1 count=2) | `dd bs=4 skip=1 count=2` | `slice -b 4:12` |
-
-#### Every Nth line (sed/awk only — slice does it too)
-
-| Task | coreutils / sed / awk / dd | slice |
-| --- | --- | --- |
-| Odd lines (1, 3, 5, ...) | `sed -n '1~2p'  /  awk 'NR%2==1'` | `slice ::2` |
-| Even lines (2, 4, 6, ...) | `sed -n '2~2p'  /  awk 'NR%2==0'` | `slice 1::2` |
-
-#### NUL-delimited records and other special cases
-
-| Task | coreutils / sed / awk / dd | slice |
-| --- | --- | --- |
-| Last NUL-delimited record (find -print0 style) | `—` | `slice -z -1:` |
-
 <!-- CHEATSHEET:END -->
 
 The bounds follow Python rather than coreutils where the two disagree: `-0`
@@ -172,10 +146,9 @@ equals `0`, so `slice -0:` selects the whole input (where `tail -n 0` selects
 nothing) and `slice :-0` selects nothing (where GNU `head -n -0` selects
 everything).
 
-A tail-relative `start` (`-N:`) cannot emit anything until the input ends, and
-holds the last `N` elements in memory while it reads — the same shape as
-`tail`. A tail-relative `end` (`:-N`) stays streaming: each element is emitted
-as soon as `N` more have arrived, so only `N` elements are ever held.
+A tail-relative `start` (`-N:`) cannot emit anything until the input ends — the
+same shape as `tail` — whereas a tail-relative `end` (`:-N`) streams its output
+as it reads.
 
 ```sh
 find . -type f -print0 | slice 0:100 -z
@@ -255,34 +228,8 @@ docker run -v `pwd`:`pwd` -w `pwd` --rm -i slice
 
 ## Development
 
-### Dev Container
-
-Open the repository in a [Dev Container](https://containers.dev/) (VS Code "Reopen in Container" or GitHub Codespaces) to get a ready-to-use environment.
-The container installs the toolchain declared in `flake.nix` via Nix and activates it automatically with [direnv](https://direnv.net/), so `cargo test` works out of the box.
-
-### Tests
-
-Run the unit tests and the end-to-end CLI tests together:
-
-```sh
-cargo test
-```
-
-CLI behavior is locked under `tests/cmd/` via [`trycmd`]: each `*.toml` case runs the built
-`slice` binary and compares its stdout, stderr, and exit code against sibling golden files.
-
-After an intentional behavior change, regenerate the expected outputs and review the diff:
-
-```sh
-TRYCMD=overwrite cargo test --test cli   # update existing golden files in place
-```
-
-When adding a brand-new case, write its `*.toml` (plus `*.stdin` and/or `*.in/`), capture the
-actual output with `TRYCMD=dump cargo test --test cli`, and copy `dump/<name>.stdout` /
-`dump/<name>.stderr` into `tests/cmd/`. Keep OS-specific lines redacted with `[..]` (currently the
-I/O-error message and the `--version` string).
-
-[`trycmd`]: https://docs.rs/trycmd
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development environment (Dev
+Container) and how to run and regenerate the tests.
 
 ## License
 

--- a/xtask/src/cheatsheet.rs
+++ b/xtask/src/cheatsheet.rs
@@ -95,6 +95,11 @@ impl Group {
 
     /// Display order of the sections.
     pub const ORDER: [Group; 4] = [Group::Line, Group::Byte, Group::Stepped, Group::Special];
+
+    /// Sections the README shows inline. The README is the showcase, not the
+    /// full reference: it keeps the common line ranges and defers byte ranges,
+    /// every-Nth-line, and NUL records to the docs site.
+    pub const README_ORDER: [Group; 1] = [Group::Line];
 }
 
 #[derive(Deserialize, Clone, Copy, PartialEq, Eq)]

--- a/xtask/src/gen.rs
+++ b/xtask/src/gen.rs
@@ -55,9 +55,10 @@ pub fn splice_readme(readme: &str, table: &str) -> Result<String, String> {
     Ok(out)
 }
 
-/// The README table is the compact view: one table per group, plus a short
-/// pointer to the full GitHub Pages cheatsheet. The full "When NOT to use
-/// slice" and caveats sections live on Pages to keep the README lean.
+/// The README table is the compact view: a table for each `README_ORDER`
+/// group, plus a short pointer to the full GitHub Pages cheatsheet. Byte
+/// ranges, every-Nth-line, NUL records, the "When NOT to use slice" section,
+/// and the caveats all live on Pages to keep the README lean.
 pub fn render_readme_table(sheet: &Cheatsheet) -> String {
     let mut out = String::new();
     out.push_str(
@@ -66,7 +67,7 @@ pub fn render_readme_table(sheet: &Cheatsheet) -> String {
          \"when NOT to use slice\" section) lives at\n\
          <https://chantsune.github.io/slice/>.\n\n",
     );
-    for group in Group::ORDER {
+    for group in Group::README_ORDER {
         let rows: Vec<&Row> = sheet.rows.iter().filter(|r| r.group == group).collect();
         if rows.is_empty() {
             continue;


### PR DESCRIPTION
Reorder Installation easiest-first (script, prebuilt binaries, then the package managers, then build-from-source) so the no-build paths lead and the two Cargo entries sit together.

Narrow the inline cheatsheet to the common line ranges via a new README_ORDER; byte ranges, every-Nth-line, and NUL records now defer to the docs site, matching what the intro already claimed.

Drop the tail-relative memory mechanics, keeping only the user-observable streaming behavior, and move the development and test instructions into a new CONTRIBUTING.md.