### PR TITLE
:lock: Whitelist published crate files to prevent leaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,16 @@ repository = "https://github.com/ChanTsune/slice.git"
 categories = ["text-processing", "command-line-utilities"]
 keywords = ["text", "utility", "tool"]
 rust-version = "1.85"
-# `docs/` is the GitHub Pages source (cheatsheet SSOT + generated HTML) and
-# `.cargo/` holds the local `cargo xtask` alias; both are repository tooling,
-# not part of the published crate.
-exclude = ["/docs", "/.cargo", "/install.sh", "/install.ps1"]
+# LICENSE-* must be listed explicitly: the SPDX `license` field above does
+# not auto-include them the way a `license-file` field would.
+include = [
+    "/src",
+    "/tests",
+    "/README.md",
+    "/CHANGELOG.md",
+    "/LICENSE-APACHE",
+    "/LICENSE-MIT",
+]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Switch Cargo.toml packaging from an `exclude` blocklist to an `include` whitelist so only crate sources, tests, README, CHANGELOG, and both license files ship. Dev/CI/infra files (.github, .devcontainer, Nix, Docker, release.toml, .envrc, etc.) no longer reach the published crate, and any future stray secret at the repo root cannot leak by default.

LICENSE-* are listed explicitly because the SPDX `license` field does not auto-include them the way a `license-file` target would.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined crate publication configuration to ensure a cleaner package distribution by explicitly specifying included files, preventing unnecessary root-level files from being shipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->