### PR TITLE
:wrench: Modernize the Nix flake (schema, lockfile, README)

### DIFF
--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -10,14 +10,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
       - name: Building package
-        run: nix-build . -A defaultPackage.x86_64-linux
+        run: nix-build . -A packages.x86_64-linux.default
   build_flakes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - name: Check flake
+        run: nix flake check
       - name: Building package
         run: nix build

--- a/README.md
+++ b/README.md
@@ -54,8 +54,30 @@ brew install chantsune/tap/slice
 
 ### Via Nix
 
+Try without installing:
+
 ```sh
-nix-env --install -f https://github.com/chantsune/slice/tarball/main
+nix run github:ChanTsune/slice -- :5 file.txt
+```
+
+Install permanently:
+
+```sh
+nix profile add github:ChanTsune/slice
+```
+
+To contribute, enter the development shell after cloning:
+
+```sh
+nix develop
+# or automatically with direnv:
+direnv allow
+```
+
+Non-flake fallback:
+
+```sh
+nix-env --install -f https://github.com/ChanTsune/slice/tarball/main
 ```
 
 ### Via Cargo

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,38 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "naersk",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1752475459,
+        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1698420672,
-        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "lastModified": 1781258734,
+        "narHash": "sha256-rfZT1gFztHDqA4gcFLO/Qv74bulhW/mXYqIHYTmc1lA=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "rev": "3ddafa67a4c7d06483995c85c66a2d285b738833",
         "type": "github"
       },
       "original": {
@@ -21,25 +44,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704161960,
-        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
+        "lastModified": 1752077645,
+        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
+        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741865919,
-        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -54,6 +79,23 @@
         "naersk": "naersk",
         "nixpkgs": "nixpkgs_2",
         "utils": "utils"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752428706,
+        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {
@@ -76,11 +118,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,15 +10,23 @@
       let
         pkgs = import nixpkgs { inherit system; };
         naersk-lib = pkgs.callPackage naersk { };
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
       in
       {
-        defaultPackage = naersk-lib.buildPackage {
-            name = "slice";
-            src = ./.;
+        packages.default = naersk-lib.buildPackage {
+          name = "slice";
+          version = cargoToml.package.version;
+          src = ./.;
+          meta = with pkgs.lib; {
+            description = "Slice file contents using Python-like slice notation";
+            homepage = "https://github.com/ChanTsune/slice";
+            license = with licenses; [ asl20 mit ];
+            mainProgram = "slice";
+          };
         };
-        devShell = with pkgs; mkShell {
-          buildInputs = [ cargo rustc rustfmt rustPackages.clippy ];
-          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [ cargo rustc rustfmt rustPackages.clippy ];
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
         };
       });
 }


### PR DESCRIPTION
## What

Brings the Nix packaging up to date for flake users.

- **Migrate to the current flake output schema** — replace the deprecated `defaultPackage`/`devShell` with `packages.default`/`devShells.default`, and add package `meta` (description, homepage, license, mainProgram) with `version` sourced from `Cargo.toml`. The `build_nix.yml` workflow is updated in the *same* commit because its `build_legacy` job references the flake output attribute by name — the rename and the CI reference must move together so the build stays green at every commit.
- **Update `flake.lock`** — naersk (2023-10 → 2026-06), nixpkgs (2025-03 → 2026-06), flake-utils (2023-12 → 2024-11).
- **README** — make the Nix section flake-first: `nix run` to try, `nix profile add` to install, `nix develop`/`direnv allow` for contributors, `nix-env` kept as the non-flake fallback. Also fixes `chantsune` → `ChanTsune` in the tarball URL.

## Verification

- `nix build` and `nix flake check` pass.
- The schema-migration commit was verified to build (`nix-build -A packages.<system>.default`) and pass `nix flake check` on its own with the *old* lockfile, so each commit is independently buildable.
- CI (`build_legacy` + `build_flakes`) green on the source branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced Nix installation instructions with new quick-start examples using `nix run`, persistent installation via `nix profile add`, and development environment guidance with `nix develop`.

* **Chores**
  * Refined GitHub Actions CI workflow and updated Nix flake configuration structure for improved build handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->