### PR TITLE
:construction_worker: Install gh via Nix profile in devcontainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/nix:1": {
+      "version": "1.3.1",
+      "resolved": "ghcr.io/devcontainers/features/nix@sha256:8953a9da475055d140db0ede314e8e1b117d28c1eabf289c1b07c7619ce6c078",
+      "integrity": "sha256:8953a9da475055d140db0ede314e8e1b117d28c1eabf289c1b07c7619ce6c078"
+    }
+  }
+}

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -10,7 +10,7 @@ set -euxo pipefail
 # The direnv volume is created root-owned on first mount.
 sudo chown "$(id -un):$(id -gn)" "$HOME/.local/share/direnv"
 
-nix profile install nixpkgs#direnv nixpkgs#nix-direnv
+nix profile add nixpkgs#direnv nixpkgs#nix-direnv nixpkgs#gh
 
 # nix-direnv caches the dev shell and protects it from garbage collection.
 mkdir -p "$HOME/.config/direnv"


### PR DESCRIPTION
## What

Adds the GitHub CLI (`gh`) to the devcontainer so it is available in a fresh container without manual setup.

`on-create.sh` installs it through the Nix profile alongside `direnv`/`nix-direnv`, keeping the toolchain consistent with the rest of the Nix-managed environment. The `nix profile install` invocation is also updated to the current `nix profile add` spelling.

## Notes

- Independent of the flake packaging changes (#234); touches only `.devcontainer/`.
- Takes effect on the next devcontainer rebuild.