### PR TITLE
:sparkles: Ship shell completions and man page in the Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,22 @@
           name = "slice";
           version = cargoToml.package.version;
           src = ./.;
+
+          nativeBuildInputs = [ pkgs.installShellFiles ];
+
+          # Ship the bash/zsh/fish completions and man page that the release
+          # tarball provides. naersk copies the built binary into $out/bin
+          # before running postInstall, so it can generate them here.
+          postInstall = ''
+            installShellCompletion --cmd slice \
+              --bash <($out/bin/slice --generate complete-bash) \
+              --zsh  <($out/bin/slice --generate complete-zsh) \
+              --fish <($out/bin/slice --generate complete-fish)
+
+            $out/bin/slice --generate man > slice.1
+            installManPage slice.1
+          '';
+
           meta = with pkgs.lib; {
             description = "Slice file contents using Python-like slice notation";
             homepage = "https://github.com/ChanTsune/slice";


### PR DESCRIPTION
## What

Nix users currently get a bare `slice` binary, while the release tarball and Homebrew ship shell completions and a man page. This closes that gap.

Adds `installShellFiles` to `nativeBuildInputs` and a `postInstall` hook on `packages.default` that generates and installs:

- bash completion → `share/bash-completion/completions/slice.bash`
- zsh completion → `share/zsh/site-functions/_slice`
- fish completion → `share/fish/vendor_completions.d/slice.fish`
- man page → `share/man/man1/slice.1.gz`

It reuses the binary's own `slice --generate complete-bash|complete-zsh|complete-fish|man` (the same interface `release.yml` uses). naersk copies the binary into `$out/bin` before `postInstall` runs, so it can be invoked to produce the artifacts.

PowerShell is intentionally omitted: `installShellFiles` has no PowerShell helper, and a `.ps1` at a hand-picked path is not auto-loaded by anything on Nix, so it would add a non-functional file.

## Verification

Built locally and inspected the output:

- `nix build` succeeds; `nix flake check` passes; `nix run` still resolves `mainProgram = slice`.
- All four artifacts present and non-empty; the fish completion is byte-identical to the generator output; the man page is valid gzipped roff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell completion scripts now available for bash, zsh, and fish shells, enhancing command-line usability with intelligent tab completion
  * Man page documentation installed by default, providing comprehensive offline reference and detailed command information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->