### PR TITLE
:shirt: Enable `nix fmt` via nixfmt-tree

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,9 @@
-(import (
-  fetchTarball {
+(import
+  (fetchTarball {
     url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
-) {
-  src =  ./.;
-}).defaultNix
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+  })
+  {
+    src = ./.;
+  }
+).defaultNix

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,15 @@
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, utils, naersk }:
-    utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      utils,
+      naersk,
+    }:
+    utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
         naersk-lib = pkgs.callPackage naersk { };
@@ -36,13 +43,26 @@
           meta = with pkgs.lib; {
             description = "Slice file contents using Python-like slice notation";
             homepage = "https://github.com/ChanTsune/slice";
-            license = with licenses; [ asl20 mit ];
+            license = with licenses; [
+              asl20
+              mit
+            ];
             mainProgram = "slice";
           };
         };
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [ cargo rustc rustfmt rustPackages.clippy ];
+          buildInputs = with pkgs; [
+            cargo
+            rustc
+            rustfmt
+            rustPackages.clippy
+          ];
           RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
         };
-      });
+
+        # `nix fmt` — nixfmt-tree is a zero-config treefmt wrapper that
+        # recursively formats every *.nix file with nixfmt (RFC style).
+        formatter = pkgs.nixfmt-tree;
+      }
+    );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,9 @@
-(import (
-  fetchTarball {
+(import
+  (fetchTarball {
     url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
-) {
-  src =  ./.;
-}).shellNix
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+  })
+  {
+    src = ./.;
+  }
+).shellNix


### PR DESCRIPTION
## What

Adds `formatter = pkgs.nixfmt-tree;` to the flake so `nix fmt` works out of the box, and applies it once to the existing `.nix` files.

`nixfmt-tree` is a zero-config treefmt wrapper (it pins its own config) that recursively formats every `*.nix` file with `nixfmt` (RFC style). A bare `nixfmt-rfc-style` cannot recurse a directory, which is why the treefmt wrapper is used.

The reformat of `flake.nix`/`default.nix`/`shell.nix` is purely cosmetic (layout only) — package outputs and evaluation are unchanged. Committing the reformat alongside the formatter keeps the tree idempotent: a second `nix fmt` produces no diff.

## Verification

- `nix eval .#formatter.<system>.name` → `nixfmt-tree-2.5.0` (from the existing pinned nixpkgs; no `flake.lock` change).
- `nix fmt` → formats 3 files, exit 0; a second run reports `0 changed` (idempotent).
- `nix flake check` passes and `nix build` still produces `slice-0.5.0`.
- No repo-level `treefmt.toml` needed; `.git` and `.gitignore`d paths are skipped.