### PR TITLE
:memo: Add status badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,21 @@
 
 # Slice
 
+[![CI][ci-badge]][ci-url]
+[![Crates.io][crates-badge]][crates-url]
+[![Downloads][downloads-badge]][crates-url]
+[![License][license-badge]](#license)
+[![MSRV][msrv-badge]][crates-url]
+
 Slice is a command-line tool written in Rust that allows you to slice the contents of a file using syntax similar to Python's slice notation.
 
-![test_workflow](https://github.com/ChanTsune/slice/actions/workflows/test.yml/badge.svg)
-[![Crates.io][crates-badge]][crates-url]
-
+[ci-badge]: https://github.com/ChanTsune/slice/actions/workflows/test.yml/badge.svg
+[ci-url]: https://github.com/ChanTsune/slice/actions/workflows/test.yml
 [crates-badge]: https://img.shields.io/crates/v/slice-command.svg
 [crates-url]: https://crates.io/crates/slice-command
+[downloads-badge]: https://img.shields.io/crates/d/slice-command.svg
+[license-badge]: https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg
+[msrv-badge]: https://img.shields.io/crates/msrv/slice-command.svg
 
 ## Installation
 


### PR DESCRIPTION
## What

Adds a centered row of status badges under the title so the README reads as a maintained, published CLI at a glance:

- **CI** — `test.yml` workflow status (now linked to the workflow)
- **Crates.io** — published version
- **Downloads** — crates.io download count
- **License** — `Apache-2.0 OR MIT`
- **MSRV** — minimum supported Rust version (1.85)

All badge URLs were verified to return real values (e.g. MSRV → `1.85`, downloads → `12k`).

The license badge uses a static shields badge rather than `crates/l`, because shields' crates license endpoint renders the dual-license SPDX expression (`Apache-2.0 OR MIT`) as `invalid`.

Dropped from consideration: docs.rs (binary crate, no library API) and a Homebrew badge (custom tap, no clean badge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README header to include a centered logo.
  * Reorganized and refreshed the status/badge links to prominently display CI status, crate version and downloads, license, and minimum supported Rust version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->