### PR TITLE
:construction_worker: Harden the crate publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Rust crate
 on:
   push:
     tags:
-      - '*'
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publish:
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust
       - name: Publish crate
-        run: cargo publish
+        run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_IO_API_KEY }}"


### PR DESCRIPTION
## What

Two safety fixes to `publish.yml`, which holds the crates.io token:

1. **Scope the tag trigger.** It fired `cargo publish` on `*` (any tag), with no version guard. `release.yml` already restricts to the SemVer pattern `[0-9]+.[0-9]+.[0-9]+`; this aligns `publish.yml` with it, so a stray or test tag push can no longer publish to crates.io.
2. **`cargo publish --locked`.** Publishes against the committed (CI-audited) `Cargo.lock` instead of a freshly resolved dependency graph.

## Why

`cargo publish` is irreversible per version. The previous `'*'` trigger meant any pushed tag — including throwaway/test tags — would attempt a publish; `--locked` ensures the published artifact matches the dependency set that was tested.

No behavior change for real releases: version tags (`X.Y.Z`) still publish exactly as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process with stricter semantic versioning validation and locked dependency enforcement to ensure consistent, reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->