### PR TITLE
:construction_worker: Publish SHA256SUMS with release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,3 +184,50 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ needs.create-release.outputs.slice_version }}
       run: gh release upload "$TAG" "$ASSET" --clobber
+
+  checksums:
+    name: checksums
+    needs: ['create-release', 'build-release']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release archives
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.create-release.outputs.slice_version }}
+        run: |
+          rm -rf dist
+          mkdir dist
+          # Completions/man are uploaded as a GitHub Actions artifact, not a
+          # release asset, so they are never matched here -- only the per-target
+          # archives are. Scoping with --pattern also keeps a re-run from
+          # re-downloading (and self-hashing) a previously published SHA256SUMS.
+          gh release download "$TAG" \
+            --dir dist \
+            --pattern 'slice-*.tar.gz' \
+            --pattern 'slice-*.zip'
+
+      - name: Generate SHA256SUMS
+        shell: bash
+        working-directory: dist
+        run: |
+          shopt -s nullglob
+          files=( slice-*.tar.gz slice-*.zip )
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::no release archives found to checksum"
+            exit 1
+          fi
+          # Hash bare filenames (not paths) so `sha256sum -c SHA256SUMS` works
+          # for users running it from the directory holding the archives.
+          sha256sum "${files[@]}" > SHA256SUMS
+          cat SHA256SUMS
+          # Self-check the manifest round-trips before we publish it.
+          sha256sum -c SHA256SUMS
+
+      - name: Upload SHA256SUMS to release
+        shell: bash
+        working-directory: dist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.create-release.outputs.slice_version }}
+        run: gh release upload "$TAG" SHA256SUMS --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--max-record-size <SIZE|unlimited>` as an opt-in guard for line/custom
   delimiter tail-relative ranges. The default remains unlimited for
   compatibility.
+- Releases now include a `SHA256SUMS` manifest to verify downloads
+  (`sha256sum -c SHA256SUMS`).
 
 ## [0.5.0] - 2026-06-13
 


### PR DESCRIPTION
## What

Adds a `checksums` job to `release.yml` that publishes a single `SHA256SUMS` manifest alongside the per-target release archives, so packagers (Homebrew/AUR/Debian/nixpkgs) and hardened CI can verify downloads instead of trusting on faith.

How it works:
- `needs: [create-release, build-release]` — runs only after every matrix leg has uploaded its archive.
- Runs on `ubuntu-latest` only, so GNU `sha256sum` is always available (avoids the macOS/Windows `sha256sum`-absent problem a per-matrix step would hit).
- Downloads just the archives (`gh release download --pattern 'slice-*.tar.gz' --pattern 'slice-*.zip'`), hashes bare filenames, and uploads `SHA256SUMS` with `--clobber`.
- Hardened: empty-archive-set guard, and a `sha256sum -c` self-check before upload. **Fail-closed** — if any build leg fails, the job is skipped and no (partial) manifest ships.

Completions/man are Actions artifacts (not release assets), so they are correctly excluded from the manifest.

Verifiers run `sha256sum -c SHA256SUMS` (Linux) or `shasum -a 256 -c SHA256SUMS` (macOS) from the download directory.

## Verification

`release.yml` only triggers on a version tag, so PR CI does not exercise this job. De-risked by:
- **actionlint**: no findings on the new job (only pre-existing info-level SC2086 in unrelated existing steps).
- **Local /tmp simulation** of the exact step bash: generate → `sha256sum -c` self-check (exit 0) → tamper detection (exit 1) → empty-set guard → `shasum -a 256 -c` cross-compat — all pass.
- **Read-only check** against the live `0.5.0` release: all 8 assets match the `slice-*.tar.gz`/`slice-*.zip` globs (5 tar.gz + 3 zip), confirming the manifest will cover exactly the archives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release archives now include a `SHA256SUMS` manifest to help verify download integrity.
  * You can validate archives using `sha256sum -c SHA256SUMS` to detect corruption or mismatches.
* **Documentation**
  * Updated the changelog to reflect that `SHA256SUMS` is included with release archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->