### PR TITLE
:recycle: Unify the plan-dispatch fork into a single run()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -663,6 +663,34 @@ fn regular_len(file: &fs::File) -> Option<u64> {
     (metadata.is_file() && metadata.len() > 0).then_some(metadata.len())
 }
 
+/// Dispatch one input through its plan. The only per-call-site differences are
+/// the `skip` strategy (read-discard on stdin, seek on files) and whether a
+/// `len` is known up front to resolve a deferred plan eagerly — pass `None` for
+/// a stream that can't report its length (so it keeps streaming via
+/// `apply_deferred`).
+fn run<R, W, S>(
+    mode: &SliceMode,
+    input: R,
+    output: W,
+    plan: Plan,
+    skip: S,
+    max_record_size: Option<usize>,
+    len: Option<u64>,
+) -> io::Result<()>
+where
+    R: BufRead,
+    W: Write,
+    S: Fn(&mut R, u64) -> io::Result<()>,
+{
+    match plan {
+        Plan::Resolved(plan) => apply(mode, input, output, plan, skip),
+        Plan::Deferred(deferred) => match len.and_then(|len| deferred.resolve(len)) {
+            Some(plan) => apply(mode, input, output, plan, skip),
+            None => apply_deferred(mode, input, output, deferred, max_record_size),
+        },
+    }
+}
+
 fn entry(args: cli::Args) -> bool {
     if let Some(kind) = args.generate {
         return stdout_status(generate_mode(stdout().lock(), kind));
@@ -701,12 +729,9 @@ fn entry(args: cli::Args) -> bool {
     if args.files.is_empty() {
         let input = buf_reader(stdin().lock(), io_buffer_size);
         let output = buf_writer(stdout().lock(), io_buffer_size);
-        let result = match plan {
-            Plan::Resolved(plan) => apply(&mode, input, output, plan, discard),
-            Plan::Deferred(deferred) => {
-                apply_deferred(&mode, input, output, deferred, max_record_size)
-            }
-        };
+        // stdin can't report a length or seek, so deferred plans stay
+        // streaming (len = None) and skipping is read-and-discard.
+        let result = run(&mode, input, output, plan, discard, max_record_size, None);
         stdout_status(result)
     } else {
         // A single file never gets a header, so -q only matters for 2+ files.
@@ -720,21 +745,13 @@ fn entry(args: cli::Args) -> bool {
             |input: io::BufReader<fs::File>, output| {
                 let seek =
                     |r: &mut io::BufReader<fs::File>, n| r.seek(SeekFrom::Start(n)).map(drop);
-                match plan {
-                    Plan::Resolved(plan) => apply(&mode, input, output, plan, seek),
-                    Plan::Deferred(deferred) => {
-                        // Byte offsets resolve against the file size, rejoining
-                        // the seek/copy fast paths; line/delimiter counts stay
-                        // unknowable up front, so those keep streaming.
-                        let len = matches!(mode, SliceMode::Bytes)
-                            .then(|| regular_len(input.get_ref()))
-                            .flatten();
-                        match len.and_then(|len| deferred.resolve(len)) {
-                            Some(plan) => apply(&mode, input, output, plan, seek),
-                            None => apply_deferred(&mode, input, output, deferred, max_record_size),
-                        }
-                    }
-                }
+                // Byte offsets resolve against the file size, rejoining the
+                // seek/copy fast paths; line/delimiter counts stay unknowable up
+                // front, so those keep streaming.
+                let len = matches!(mode, SliceMode::Bytes)
+                    .then(|| regular_len(input.get_ref()))
+                    .flatten();
+                run(&mode, input, output, plan, seek, max_record_size, len)
             },
         )
     }
@@ -1977,14 +1994,9 @@ mod tests {
                 let plan = SliceRange::from_str(range).unwrap().plan();
                 let apply_with = |mode: &SliceMode| {
                     let mut out = Vec::new();
-                    match plan {
-                        Plan::Resolved(plan) => {
-                            apply(mode, INPUT, &mut out, plan, discard).expect("")
-                        }
-                        Plan::Deferred(deferred) => {
-                            apply_deferred(mode, INPUT, &mut out, deferred, None).expect("")
-                        }
-                    }
+                    // Route through the same dispatcher entry() uses, with the
+                    // stdin-like settings (no length, read-discard skip).
+                    run(mode, INPUT, &mut out, plan, discard, None, None).expect("");
                     out
                 };
                 assert_eq!(


### PR DESCRIPTION
## What

The `match plan { Plan::Resolved => apply(...), Plan::Deferred => apply_deferred(...) }` dispatch was duplicated in three places:

- the stdin path (no files),
- the `multi()` per-file closure (with the byte-mode length resolution),
- the `routes_through_byte_machinery` test oracle.

Adding a new plan family (e.g. a future `Plan::Reverse`) would mean editing all three in lockstep, and the test copy could silently drift. This extracts the fork into one generic `run(mode, input, output, plan, skip, max_record_size, len)`:

- **stdin** passes `len = None` → deferred plans keep streaming (`None.and_then` short-circuits, so `apply_deferred` is reached exactly as before).
- **multi()** passes the same `matches!(mode, Bytes).then(regular_len).flatten()` → byte offsets still resolve against file size and rejoin the seek fast path.
- the **oracle** now exercises the shared dispatcher instead of its own copy.

This is a pure refactor groundwork item (one of the prerequisites for negative-step/reverse support); no user-facing behavior change, so `skip-changelog`.

## Behavior preservation

- `cargo fmt --check`, `cargo build --locked`, full `cargo test --locked` (trycmd golden suite + unit tests incl. the modified oracle) all pass unchanged; `cargo clippy` adds no new warning.
- Verified each call site reduces to byte-identical behavior (adversarial multi-lens review).

**One transparent caveat:** the `regular_len` (read-only `fstat`) call moved from inside the deferred arm to before `run()`, so a *resolved* plan in multi-file byte mode now does one extra `stat` whose result is ignored. It does not consume the reader or move the file position — output, exit codes, and errors are byte-for-byte identical. If you'd prefer zero syscall delta, I can make `len` a lazy `FnOnce(&R)` evaluated only on the deferred arm; I judged that not worth the added signature complexity, but happy to switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal execution flow by consolidating how input streaming and deferred processing plans are handled. Optimized how input length is calculated for different input sources, particularly for stdin and file-based inputs, to improve system efficiency and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->