### PR TITLE
:construction_worker: Add RISC-V (riscv64gc-unknown-linux-musl) release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
           - linux
           - linux-arm
           - linux-arm64
+          - linux-riscv64
           - macos
           - macos-arm
           - win-msvc
@@ -85,6 +86,11 @@ jobs:
           os: ubuntu-24.04-arm
           rust: stable
           target: aarch64-unknown-linux-musl
+          cross: false
+        - build: linux-riscv64
+          os: ubuntu-24.04-riscv
+          rust: stable
+          target: riscv64gc-unknown-linux-musl
           cross: false
         # macos-15 runners are arm64; x86_64-apple-darwin is a cross-compile
         # through the target added by setup-rust.
@@ -133,9 +139,11 @@ jobs:
       run: |
         cargo install cross
         echo "CARGO=cross" >> $GITHUB_ENV
+    # Native musl targets (aarch64, riscv64) need musl-gcc on the host; the
+    # x86_64 musl build is cross-only, so its cross image supplies it instead.
     - name: Setup musl tools
       shell: bash
-      if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
+      if: ${{ !matrix.cross && endsWith(matrix.target, '-linux-musl') }}
       run: sudo apt-get update && sudo apt-get install -y musl-tools
     - name: Setup target flags
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compatibility.
 - Releases now include a `SHA256SUMS` manifest to verify downloads
   (`sha256sum -c SHA256SUMS`).
+- Prebuilt binary for RISC-V Linux (`riscv64gc-unknown-linux-musl`); the
+  `curl … | sh` installer now resolves RISC-V hosts.
 
 ## [0.5.0] - 2026-06-13
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ choose the install location.
 
 ### Prebuilt binaries
 
-Prebuilt archives for Linux, macOS, and Windows (x86 and ARM) are published on
-the [GitHub Releases](https://github.com/ChanTsune/slice/releases) page; see that
+Prebuilt archives for Linux (x86, ARM, and RISC-V), macOS, and Windows (x86 and
+ARM) are published on the
+[GitHub Releases](https://github.com/ChanTsune/slice/releases) page; see that
 page for the targets covered by the latest release. Each archive bundles shell
 completions (`complete/`) and the man page (`doc/`) alongside the binary.
 

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ detect_target() {
 		case "$arch" in
 		x86_64 | amd64) echo "x86_64-unknown-linux-musl" ;;
 		aarch64 | arm64) echo "aarch64-unknown-linux-musl" ;;
+		riscv64) echo "riscv64gc-unknown-linux-musl" ;;
 		armv7l | armv6l | arm) echo "arm-unknown-linux-gnueabihf" ;;
 		*) err "unsupported Linux architecture: $arch" ;;
 		esac


### PR DESCRIPTION
## Summary

Publish a RISC-V Linux release binary (`riscv64gc-unknown-linux-musl`), built natively on the `ubuntu-24.04-riscv` runner, and resolve RISC-V hosts in `install.sh` so `curl … | sh` installs there. This matches the musl-static build already used for the other 64-bit Linux targets.

## Notes

- `install-test.yml` coverage is intentionally left to a follow-up: the installer test runs against the *latest published* release, so a RISC-V job can only pass once a release containing the new asset exists.
- The native RISC-V build runs only at tag time (`release.yml` triggers on tags); it is not exercised by PR CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prebuilt Linux binaries for RISC-V systems.
  * The installer now detects RISC-V Linux machines and downloads the correct build.
* **Documentation**
  * Updated the README and changelog to list RISC-V among supported prebuilt Linux downloads.
* **Bug Fixes**
  * Improved release build setup so required musl tools are installed for all native Linux musl builds, helping release packaging succeed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->