### PR TITLE
:construction_worker: Fix unrendered {{version}} in release commit message

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,6 +1,10 @@
 publish = false
 push = false
 tag = false
+# The xtask member makes this a multi-package workspace; a consolidated
+# commit message can't render {{version}} there (versions aren't shared),
+# so commit per package. Only slice-command is released, so it stays one commit.
+consolidate-commits = false
 # The repo's tags have no `v` prefix (release.yml triggers on bare versions).
 tag-name = "{{version}}"
 pre-release-commit-message = ":bookmark: Bump version to {{version}}"


### PR DESCRIPTION
## Summary
Set `consolidate-commits = false` in release.toml. The xtask member made the repo a multi-package workspace, where cargo-release's consolidated commit message cannot render `{{version}}` (versions are not shared), leaving the placeholder literally in release commits (see `release/minor-0.6.0`).

## Verification
Ran `cargo release minor --no-publish --no-push --no-tag --execute --no-confirm` (cargo-release 1.1.2) in a clone of this branch: the commit message renders as `:bookmark: Bump version to 0.6.0`, still a single commit touching Cargo.toml / Cargo.lock / CHANGELOG.md, with xtask skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release settings to handle package releases more reliably in multi-package projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->