### PR TITLE
:construction_worker: Add FreeBSD (x86_64-unknown-freebsd) release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
           - linux-arm
           - linux-arm64
           - linux-riscv64
+          - freebsd
           - macos
           - macos-arm
           - win-msvc
@@ -92,6 +93,11 @@ jobs:
           rust: stable
           target: riscv64gc-unknown-linux-musl
           cross: false
+        - build: freebsd
+          os: ubuntu-latest
+          rust: stable
+          target: x86_64-unknown-freebsd
+          cross: true
         # macos-15 runners are arm64; x86_64-apple-darwin is a cross-compile
         # through the target added by setup-rust.
         - build: macos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`sha256sum -c SHA256SUMS`).
 - Prebuilt binary for RISC-V Linux (`riscv64gc-unknown-linux-musl`); the
   `curl … | sh` installer now resolves RISC-V hosts.
+- Prebuilt binary for FreeBSD (`x86_64-unknown-freebsd`); the
+  `curl … | sh` installer now resolves FreeBSD hosts.
 
 ## [0.5.0] - 2026-06-13
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ choose the install location.
 
 ### Prebuilt binaries
 
-Prebuilt archives for Linux (x86, ARM, and RISC-V), macOS, and Windows (x86 and
-ARM) are published on the
+Prebuilt archives for Linux (x86, ARM, and RISC-V), macOS, Windows (x86 and
+ARM), and FreeBSD are published on the
 [GitHub Releases](https://github.com/ChanTsune/slice/releases) page; see that
 page for the targets covered by the latest release. Each archive bundles shell
 completions (`complete/`) and the man page (`doc/`) alongside the binary.

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,8 @@ have() {
 }
 
 # Map the host to one of the published release target triples. Linux ships musl
-# builds (and a gnueabihf build for 32-bit arm); macOS ships native darwin.
+# builds (and a gnueabihf build for 32-bit arm); macOS and FreeBSD ship native
+# builds.
 detect_target() {
 	os=$(uname -s)
 	arch=$(uname -m)
@@ -41,6 +42,12 @@ detect_target() {
 		x86_64) echo "x86_64-apple-darwin" ;;
 		arm64 | aarch64) echo "aarch64-apple-darwin" ;;
 		*) err "unsupported macOS architecture: $arch" ;;
+		esac
+		;;
+	FreeBSD)
+		case "$arch" in
+		x86_64 | amd64) echo "x86_64-unknown-freebsd" ;;
+		*) err "unsupported FreeBSD architecture: $arch" ;;
 		esac
 		;;
 	*)


### PR DESCRIPTION
## Summary
Add a FreeBSD (`x86_64-unknown-freebsd`) prebuilt binary to the release assets, cross-compiled with `cross` on `ubuntu-latest`. The `curl … | sh` installer now resolves FreeBSD hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FreeBSD support for prebuilt downloads and installation detection.
  * FreeBSD is now included in the release build matrix, producing a dedicated binary.

* **Documentation**
  * Updated the changelog and README to mention FreeBSD availability.
  * Installation guidance now reflects supported FreeBSD hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->