### PR TITLE
Fix checksums release job failing without repo context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,10 @@ jobs:
     name: checksums
     needs: ['create-release', 'build-release']
     runs-on: ubuntu-latest
+    # This job doesn't check out the repo, so gh can't infer the target from a
+    # git remote; name it explicitly instead.
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Download release archives
         shell: bash


### PR DESCRIPTION
## Summary

The `checksums` release job failed with `fatal: not a git repository` because it never checks out the repo, so `gh release download`/`upload` couldn't infer the target repository. Set `GH_REPO` at the job level so `gh` resolves the repo without a git remote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability by ensuring checksum generation targets the correct repository even when source files aren’t available in the job.
  * Added clearer workflow guidance to support more consistent release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->